### PR TITLE
Fixed marker sizes of agents in simulation plot

### DIFF
--- a/code/SetupSimulationGraphics.m
+++ b/code/SetupSimulationGraphics.m
@@ -4,7 +4,6 @@ hFig1 = figure(1);
 clf(hFig1);
 set(hFig1,'Position',[800 400 500 500]);
 
-sizeAdjustment=2*0.3*1; 
 hold on;
 hWallPlot = plot(walls(:,1),walls(:,2),'LineWidth',2,'Color','k');
 hTargetPlot = plot(targetPosition(1),targetPosition(2),'rx','MarkerSize',10);
@@ -12,18 +11,31 @@ hSocialPlot = gplot(socialCorrelations ,agents(:,PROPERTIES.Position),'k-');
 hAgentPlot = scatter(agents(:,PROPERTIES.Position(1)),agents(:,PROPERTIES.Position(2)),'filled');
 hold off;
 
+% Set agent colors
+agentColors = ones(nAgents,1)*[0 0.4 1]; % Light blue
+set(hAgentPlot,'CData',agentColors);
+
 box on;
 axis equal tight;
 axis([-roomSize(1)*0.25 roomSize(1)*1.25 -roomSize(2)*0.25 roomSize(2)*1.25]);
 set(gca,'XTick',[]);
 set(gca,'YTick',[]);
+
+% --- Adjust marker size for agents ---
+% Get size of figure in 'Point' units
 currentunits = get(gca,'Units');
 set(gca, 'Units', 'Points');
 axpos = get(gca,'Position');
 set(gca, 'Units', currentunits);
-markerWidthX = sizeAdjustment/diff(xlim)*axpos(3);
-markerWidthY = sizeAdjustment/diff(ylim)*axpos(4);
-set(hAgentPlot, 'SizeData', markerWidthX.*markerWidthY);
-hTimeStamp = text(-5, -7, sprintf('Time: %d',0));
+
+radius = agents(:,PROPERTIES.Radius);
+markerWidth = (2*radius)./diff(xlim).*axpos(3);
+markerHeight = (2*radius)./diff(ylim).*axpos(4);
+set(hAgentPlot, 'SizeData', markerWidth.*markerHeight);
+% --- End of marker size adjustment ---
+
+% Create time stamp for simulation
+hTimeStamp = text(-0.25*roomSize(1), -0.35*roomSize(2), sprintf('Time: %d',0));
 set(hTimeStamp, 'Interpreter','Latex','FontSize',14);
+
 drawnow;


### PR DESCRIPTION
Fixed marker sizes of agents in simulation plot

**Note:** Sizes are not adjusted when manually changing the size of the figure window
